### PR TITLE
Retrieve interfaces in the topological order in registries

### DIFF
--- a/Buform/Extensions/TypeExtensions.cs
+++ b/Buform/Extensions/TypeExtensions.cs
@@ -1,0 +1,23 @@
+namespace Buform.Extensions;
+
+internal static class TypeExtensions
+{
+    public static List<Type> GetInterfacesTopDown(this Type? type)
+    {
+        var interfaces = new List<Type>();
+
+        while (type != null)
+        {
+            var all = type.GetInterfaces();
+
+            interfaces.AddRange(
+                all.Except(all.SelectMany(i => i.GetInterfaces()))
+                    .Except(type.BaseType?.GetInterfaces() ?? [])
+            );
+
+            type = type.BaseType;
+        }
+
+        return interfaces;
+    }
+}

--- a/Buform/Platforms/Android/FormRegistry.cs
+++ b/Buform/Platforms/Android/FormRegistry.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Android.Runtime;
+using Buform.Extensions;
 using Fedandburk.Common.Extensions;
 
 namespace Buform;
@@ -65,9 +66,7 @@ internal sealed class FormRegistry
             return true;
         }
 
-        var interfaceTypes = dataType
-            .GetInterfaces()
-            .Except(dataType.GetInterfaces().SelectMany(item => item.GetInterfaces()));
+        var interfaceTypes = dataType.GetInterfacesTopDown();
 
         foreach (var interfaceType in interfaceTypes)
         {

--- a/Buform/Platforms/Ios/FormGroupRegistry.cs
+++ b/Buform/Platforms/Ios/FormGroupRegistry.cs
@@ -1,3 +1,5 @@
+using Buform.Extensions;
+
 namespace Buform;
 
 [Preserve(AllMembers = true)]
@@ -46,9 +48,7 @@ internal sealed class FormGroupRegistry
             return true;
         }
 
-        var interfaceTypes = groupType
-            .GetInterfaces()
-            .Except(groupType.GetInterfaces().SelectMany(item => item.GetInterfaces()));
+        var interfaceTypes = groupType.GetInterfacesTopDown();
 
         foreach (var interfaceType in interfaceTypes)
         {
@@ -75,10 +75,7 @@ internal sealed class FormGroupRegistry
             return (IFormGroupHandler)Activator.CreateInstance(type)!;
         }
 
-        var interfaceTypes = group
-            .GetType()
-            .GetInterfaces()
-            .Except(group.GetType().GetInterfaces().SelectMany(item => item.GetInterfaces()));
+        var interfaceTypes = group.GetType().GetInterfacesTopDown();
 
         foreach (var interfaceType in interfaceTypes)
         {
@@ -99,6 +96,8 @@ internal sealed class FormGroupRegistry
             typeof(TGroupView),
             RegistrationType.Class
         );
+
+        var t = typeof(TGroupView).ToString();
     }
 
     public void RegisterGroupFooterClass<TGroup, TGroupView>()

--- a/Buform/Platforms/Ios/FormItemRegistry.cs
+++ b/Buform/Platforms/Ios/FormItemRegistry.cs
@@ -1,3 +1,5 @@
+using Buform.Extensions;
+
 namespace Buform;
 
 [Preserve(AllMembers = true)]
@@ -40,9 +42,7 @@ internal sealed class FormItemRegistry
             return true;
         }
 
-        var interfaceTypes = itemType
-            .GetInterfaces()
-            .Except(itemType.GetInterfaces().SelectMany(item => item.GetInterfaces()));
+        var interfaceTypes = itemType.GetInterfacesTopDown();
 
         foreach (var interfaceType in interfaceTypes)
         {


### PR DESCRIPTION
# Summary
Retrieve interfaces in the topological order in registries to prioritize higher-level ones.